### PR TITLE
Fix: range handling

### DIFF
--- a/svdmmap.py
+++ b/svdmmap.py
@@ -12,9 +12,11 @@ https://github.com/stm32-rs/stm32-rs/blob/master/scripts/svdmmap.py
 import sys
 import copy
 import xml.etree.ElementTree as ET
+from xml.etree.ElementTree import Element
 
+from typing import List
 
-def iter_clusters(ptag):
+def iter_clusters(ptag: Element) -> List[Element]:
     registers = ptag.find('registers')
     if registers is None:
         return []
@@ -22,7 +24,7 @@ def iter_clusters(ptag):
         return registers.findall('cluster')
 
 
-def iter_registers(ptag):
+def iter_registers(ptag: Element) -> List[Element]:
     registers = ptag.find('registers')
     if registers is None:
         return []
@@ -30,7 +32,7 @@ def iter_registers(ptag):
         return registers.findall('register')
 
 
-def iter_fields(rtag):
+def iter_fields(rtag: Element) -> List[Element]:
     fields = rtag.find('fields')
     if fields is None:
         return []
@@ -82,7 +84,7 @@ def get_int(node, tag, default=None):
         return int(text, 10)
 
 
-def expand_dim(node):
+def expand_dim(node: Element):
     """
     Given a node (a cluster or a register) which may have a `dim` child,
     returns an expanded list of all such nodes with '%s' in the name replaced
@@ -104,7 +106,7 @@ def expand_dim(node):
             idxs = list(range(int(li), int(ri)+1))
         else:
             raise ValueError("Unknown dimIndex: '{idxs}'".format(**locals()))
-    nodes = []
+    nodes: List[Element] = []
     for cnt, idx in enumerate(idxs):
         name = get_string(node, 'name').replace("%s", str(idx))
         dim_node = copy.deepcopy(node)

--- a/svdmmap.py
+++ b/svdmmap.py
@@ -97,13 +97,13 @@ def expand_dim(node: Element):
     inc = get_int(node, 'dimIncrement')
     idxs = get_string(node, 'dimIndex')
     if idxs is None:
-        idxs = list(range(dim))
+        idxs = range(int(dim))
     else:
         if "," in idxs:
             idxs = idxs.split(",")
         elif "-" in idxs:
             li, ri = idxs.split("-")
-            idxs = list(range(int(li), int(ri)+1))
+            idxs = range(int(li), int(ri) + 1)
         else:
             raise ValueError("Unknown dimIndex: '{idxs}'".format(**locals()))
     nodes: List[Element] = []


### PR DESCRIPTION
This PR addresses an issue that cropped up while using the plugin with the ESP32-C3's SVD, which extensively relies on dimension ranges.

The plugin would crash and fail to read the SVD when it hit one of the `dim` node range specifications due to trying to pass a string as the argument to `range()`. This is the resulting fix after digging into why, and a small optimisation to this code by dropping the forced `list()` expansions which sped loading up a fair bit, while reducing memory utilisation.

We've also added some type annotations which helped us in diagnosing the types issue and what exactly was going on.